### PR TITLE
Refactoring

### DIFF
--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -48,7 +48,7 @@ void extract_dat(fs::path file_path) {
 
     // Getting number of files to extract
     HEADER header;
-    potter_dir.read((char *) &header, sizeof(header));
+    potter_dir.read(reinterpret_cast<char*>(&header), sizeof(header));
 
     METADATA metadata;
 
@@ -70,7 +70,7 @@ void extract_dat(fs::path file_path) {
     for (int i = 0; i < header.num_files; i++) {
 
         // Reading file metadata
-        potter_dir.read((char *) &metadata, sizeof(metadata));
+        potter_dir.read(reinterpret_cast<char*>(&metadata), sizeof(metadata));
 
         // Creating a vector to read the data from POTTER.DAT
         vector<char> mem_block(metadata.size);

--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <string>
 #include <filesystem>
+#include <vector>
 #include "extract.h"
 
 using namespace std;
@@ -35,24 +36,6 @@ bool check_dir(fs::path file_path) {
     return false;
 }
 
-string convert_file_name(char name[]) {
-
-    string file_name;
-
-    for (int i = 0; i < NAME_SIZE; i++) {
-
-        // Search for end of string
-        if (name[i] == 0x00) {
-            break;
-        }
-
-        // Adds character to the string
-        file_name += name[i];
-    }
-
-    return file_name;
-}
-
 void extract_dat(fs::path file_path) {
 
     // ifstream to read the Harry Potter DIR and DAT files
@@ -81,9 +64,6 @@ void extract_dat(fs::path file_path) {
     fs::path lev(potter_path / "LEV");
     fs::create_directory(lev);
 
-    // Memory block to hold variable size of data to read from the POTTER.DAT
-    char * mem_block;
-
     cout << "Extracting POTTER.DAT to POTTER/..." << endl;
 
     // Reading every single file information
@@ -92,15 +72,16 @@ void extract_dat(fs::path file_path) {
         // Reading file metadata
         potter_dir.read((char *) &metadata, sizeof(metadata));
 
-        // Creating a block of memory to read the data from POTTER.DAT
-        mem_block = new char[metadata.size];
+        // Creating a vector to read the data from POTTER.DAT
+        vector<char> mem_block(metadata.size);
 
         // Adjusting pointer to read the data from
         potter_dat.seekg(metadata.offset, ios::beg);
-        potter_dat.read(mem_block, metadata.size);
+        potter_dat.read(mem_block.data(), metadata.size);
 
         // Converting filename to a string
-        string file_name = convert_file_name(metadata.file_name);
+        string file_name(metadata.file_name);
+        file_name = file_name.substr(0, NAME_SIZE);
         string extension = file_name.substr(file_name.size() - 3);
 
         // Creating extracted file
@@ -112,11 +93,7 @@ void extract_dat(fs::path file_path) {
         } else {
             new_file.open(potter_path / "LEV" / file_name, ios::out | ios::binary);
         }
-        new_file.write(mem_block, metadata.size);
-        new_file.close();
-
-        // Freeing data space to be used later for the next file
-        delete[] mem_block;
+        new_file.write(mem_block.data(), metadata.size);
 
         cout << file_name << " successfully extracted." << endl;
 

--- a/src/extract.h
+++ b/src/extract.h
@@ -18,7 +18,6 @@ struct METADATA {
 };
 
 bool check_dir(fs::path);
-string convert_file_name(char name[]);
 void extract_dat(fs::path);
 
 #endif

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -54,13 +54,13 @@ void extract_lev(fs::path file_path) {
 
          // Reading header
         LEV_HEADER header;
-        lev_file.read((char *) &header, sizeof(header));
+        lev_file.read(reinterpret_cast<char*>(&header), sizeof(header));
 
         LEV_METADATA metadata;
         for (int i = 0; i < 7; i++) {
 
             // Reading metadata
-            lev_file.read((char *) &metadata, sizeof(metadata));
+            lev_file.read(reinterpret_cast<char*>(&metadata), sizeof(metadata));
 
             // Converting file name to a string
             string file_type(metadata.file_name);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,8 +22,8 @@ int main(int argc, char* argv[]) {
     if (check_dir(folder)) {
 
         extract_dat(folder);
-        extract_lang(folder / "POTTER/LANG");
-        extract_lev(folder / "POTTER/LEV");
+        extract_lang(folder / "POTTER" / "LANG");
+        extract_lev(folder / "POTTER" / "LEV");
 
         cout << "Extraction successfully completed." << endl;
 

--- a/src/text_decoder.cpp
+++ b/src/text_decoder.cpp
@@ -140,7 +140,7 @@ void decode_game_text(fs::path input_name, fs::path output_name, string decoder[
 
     do {
         // Read character and write decoded character to text file
-        lang_file.read((char *) &blk, sizeof(blk));
+        lang_file.read(reinterpret_cast<char*>(&blk), sizeof(blk));
         output_file << decoder[blk.character];
     } while ((lang_file.good()));
 }

--- a/src/textures.cpp
+++ b/src/textures.cpp
@@ -22,7 +22,7 @@ uint16_t* fill_vram(ifstream* tpsx_file, int vram_size, int offset) {
     int file_size = tpsx_file->tellg();
 
     tpsx_file->seekg(offset, ios::beg);
-    tpsx_file->read((char *) &vram_offset, sizeof(vram_offset));
+    tpsx_file->read(reinterpret_cast<char*>(&vram_offset), sizeof(vram_offset));
 
     offset += (vram_offset + 2) * 4;
     tpsx_file->seekg(offset, ios::beg);
@@ -38,7 +38,7 @@ uint16_t* fill_vram(ifstream* tpsx_file, int vram_size, int offset) {
             return VRAM;
         }
 
-        tpsx_file->read((char *) &cmd, sizeof(cmd));
+        tpsx_file->read(reinterpret_cast<char*>(&cmd), sizeof(cmd));
         
 
         // If the command is less than zero
@@ -53,7 +53,7 @@ uint16_t* fill_vram(ifstream* tpsx_file, int vram_size, int offset) {
                 return VRAM;
             }
 
-            tpsx_file->read((char *) &pixel, sizeof(pixel));
+            tpsx_file->read(reinterpret_cast<char*>(&pixel), sizeof(pixel));
 
             for (int i = 0; i < cmd; i++) {
                 VRAM[vram_length] = pixel;
@@ -77,7 +77,7 @@ uint16_t* fill_vram(ifstream* tpsx_file, int vram_size, int offset) {
                     return VRAM;
                 }
 
-                tpsx_file->read((char *) &pixel, sizeof(pixel));
+                tpsx_file->read(reinterpret_cast<char*>(&pixel), sizeof(pixel));
                 VRAM[vram_length] = pixel;
                 vram_length += 1;
 
@@ -126,7 +126,7 @@ void extract_textures(string file_name) {
 
     // Reading flag that has information about the textures offset
     uint32_t tpsx_flag;
-    tpsx_file.read((char *) &tpsx_flag, sizeof(tpsx_flag));
+    tpsx_file.read(reinterpret_cast<char*>(&tpsx_flag), sizeof(tpsx_flag));
 
     // Calculating offset based on the flag
     int offset = 0x4;
@@ -148,8 +148,8 @@ void extract_textures(string file_name) {
     int texture_count;
     int vram_size;
 
-    tpsx_file.read((char *) &texture_count, sizeof(texture_count));
-    tpsx_file.read((char *) &vram_size, sizeof(vram_size));
+    tpsx_file.read(reinterpret_cast<char*>(&texture_count), sizeof(texture_count));
+    tpsx_file.read(reinterpret_cast<char*>(&vram_size), sizeof(vram_size));
     vram_size *= 0x10000;
 
     TEXTURE_METADATA metadata;
@@ -179,7 +179,7 @@ void extract_textures(string file_name) {
     fs::create_directory(tex_path);
 
     for (int i = 0; i < texture_count; i++) {
-        tpsx_file.read((char *) &metadata, sizeof(metadata));
+        tpsx_file.read(reinterpret_cast<char*>(&metadata), sizeof(metadata));
 
         // Decrypting texpage
         texpage.x = ((metadata.texpage & 0xF) * 64) - 512;

--- a/src/textures.cpp
+++ b/src/textures.cpp
@@ -329,11 +329,7 @@ void extract_textures(string file_name) {
             new_file << ((raw_texture[i] >> 10) & 0x1F) << "\n";
         }
 
-        new_file.close();
-
         // Freeing texture memory to be used in the next iteration
         delete[] raw_texture;        
     }
-
-    tpsx_file.close();
 }


### PR DESCRIPTION
- Use vectors instead of arrays for two cases (let the vector manage the heap).
- Remove `ifstream::close()` (destructor already does this)
- Use C++ style cast (better practice)
- Use STL functions and `std::string` methods instead of loops to manipulate strings
- Remove slashes `/` of string literals used with `std::filesystem::path` objects.